### PR TITLE
Add move and copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,5 @@ NERDTreeMapOpenSplit    | **`i`**  | Open selected files in horizontal splits.
 NERDTreeMapOpenVSplit   | **`s`**  | Open selected files in vertical splits.
 NERDTreeMapOpenInTab    | **`t`**  | Open selected files in tabs.
 *n/a*                   | **`dd`** | Delete selected files from disk. If open in Vim, they remain open.
+*n/a*                   | **`m`**  | Move the selected files to another directory. If open in Vim, the buffer still points to its old location.
+*n/a*                   | **`c`**  | Copy selected files to another directory.

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -17,10 +17,18 @@ function! NERDTree_Open(target, node)
 endfunction
 
 function! NERDTree_MoveOrCopy(operation, node)
-    if !exists('g:destination')
-        let g:destination = input('Destination directory: ', g:NERDTreeFileNode.GetSelected().path.str(), 'dir')
+    if !exists('s:destination')
+        let s:destination = a:node.path.str()
+        if !a:node.path.isDirectory
+            let s:destination = fnamemodify(s:destination, ':p:h')
+        endif
+        let s:destination = input('Destination directory: ', s:destination, 'dir')
+        let s:destination .= (s:destination =~# nerdtree#slash().'$' ? '' : nerdtree#slash())
+        if !isdirectory(s:destination)
+            call mkdir(s:destination, 'p')
+        endif
     endif
-    let l:destination = g:destination . fnamemodify(a:node.path.str(), ':p:t')
+    let l:destination = s:destination . fnamemodify(a:node.path.str(), ':p:t')
     if a:operation == 'Moving'
         call a:node.rename(l:destination)
     else
@@ -52,7 +60,7 @@ function! s:ProcessSelection(action, callback, closeWhenDone, confirmEachNode) r
     let g:NERDTreeOldSortOrder = []
     call b:NERDTree.root.refresh()
     call NERDTreeRender()
-    unlet! g:destination
+    unlet! s:destination
     if a:action == 'Moving'
         echomsg "Check your buffers for files that have been renamed."
     endif

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -52,14 +52,14 @@ endfunction
 
 " --------------------------------------------------------------------------------
 " Main Processor
-function! s:ProcessSelection(action, init, callback, finish, closeWhenDone, confirmEachNode) range
+function! s:ProcessSelection(action, setup, callback, cleanup, closeWhenDone, confirmEachNode) range
     if b:NERDTree.isWinTree()
         call nerdtree#echo("Command is unavailable. Open NERDTree with :NERDTree, :NERDTreeToggle, or :NERDTreeFocus instead.")
         return
     endif
 
-    if type(a:init) == v:t_func
-        call a:init()
+    if type(a:setup) == v:t_func
+        call a:setup()
     endif
 
     let l:response = 0
@@ -77,8 +77,8 @@ function! s:ProcessSelection(action, init, callback, finish, closeWhenDone, conf
         let curLine += 1
     endwhile
 
-    if type(a:finish) == v:t_func
-        call a:finish()
+    if type(a:cleanup) == v:t_func
+        call a:cleanup()
     endif
 
     let g:NERDTreeOldSortOrder = []

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -47,7 +47,6 @@ function! NERDTree_MoveOrCopy(operation, node)
 endfunction
 
 function! POST_MoveOrCopy()
-    let g:NERDTreeOldSortOrder = []
     unlet! s:destination
 endfunction
 
@@ -82,6 +81,7 @@ function! s:ProcessSelection(action, init, callback, finish, closeWhenDone, conf
         call a:finish()
     endif
 
+    let g:NERDTreeOldSortOrder = []
     call b:NERDTree.root.refresh()
     call NERDTreeRender()
 


### PR DESCRIPTION
Closes #5 

After this PR's initial commit, bb3f28c, I altered the order of events, which I think makes better sense.

1. Prompt for the destination directory. Its default value is the directory of the first selected node.
1. Loop through the selected nodes, and perform the copy or rename. The same **`Yes/No/All/Cancel`** prompt is shown for each one.

As part of this pull request, I added support for callback functions that are executed before and after the loop. These functions are used for any setup and cleanup that needs to be done.