### PR TITLE
Allow cancel of Move/Copy by pressing Esc.

### DIFF
--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -35,11 +35,16 @@ function! PRE_MoveOrCopy()
             let s:destination = fnamemodify(s:destination, ':p:h')
         endif
         let s:destination = input('Destination directory: ', s:destination, 'dir')
+        if s:destination == ''
+            unlet! s:destination
+            return 0
+        endif
         let s:destination .= (s:destination =~# nerdtree#slash().'$' ? '' : nerdtree#slash())
         if !isdirectory(s:destination)
             call mkdir(s:destination, 'p')
         endif
     endif
+    return 1
 endfunction
 
 function! NERDTree_MoveOrCopy(operation, node)
@@ -64,7 +69,9 @@ function! s:ProcessSelection(action, setup, callback, cleanup, closeWhenDone, co
     endif
 
     if type(a:setup) == v:t_func
-        call a:setup()
+        if !a:setup()
+            return
+        endif
     endif
 
     let l:response = 0


### PR DESCRIPTION
Closes #10. (again)

Before the script loops through the selection, it will ask the user for the path into which the files are to be moved or copied. If the user presses `Esc` now when asked for the destination, the process will bypass the loop altogether, and no copying or moving will take place.