### PR TITLE
Added support for nerdtree's jump mappings + added a guard to prevent an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ By default, all operations ask to be confirmed with a `Yes/No/All/Cancel` prompt
 * `g:nerdtree_vis_confirm_copy`
 * `g:nerdtree_vis_confirm_move`
 
+A [mark](http://vimdoc.sourceforge.net/htmldoc/motion.html#mark-motions) is used to make your NERDTree's `Jump` mappings work while keeping your selection. By default the mark is on the `n` key, if you already use this key for a mark inside NERDTree you can change it via `g:nerdtree_vis_jumpmark`
+
 ## Mappings
 
 Where applicable, those key mappings match up with NERDTree settings. If not defined in your `.vimrc`, their default values are used. The mappings are as follows:
@@ -37,3 +39,9 @@ NERDTreeMapOpenInTab    | <kbd>t</kbd>  | Open selected files in tabs.
 *n/a*                   | <kbd>d</kbd> | Delete selected files from disk. If open in Vim, they remain open.
 *n/a*                   | <kbd>m</kbd>  | Move the selected files to another directory. If open in Vim, the buffer still points to its old location.
 *n/a*                   | <kbd>c</kbd>  | Copy selected files to another directory.
+NERDTreeMapJumpRoot        | <kbd>P</kbd>    | Jump to the tree root.
+NERDTreeMapJumpParent      | <kbd>p</kbd>    | Jump to the parent node of the cursor node.
+NERDTreeMapJumpFirstChild  | <kbd>K</kbd>    | Jump to the first child of the cursor node's parent.
+NERDTreeMapJumpLastChild   | <kbd>J</kbd>    | Jump to the last child of the cursor node's parent.
+NERDTreeMapJumpPrevSibling | <kbd>c-k</kbd>  | Jump to the previous sibling of the cursor node.
+NERDTreeMapJumpNextSibling | <kbd>c-j</kbd>  | Jump to the next sibling of the cursor node.

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -11,19 +11,20 @@ execute "vnoremap <buffer> d :call <SID>ProcessSelection('Deleting', '', functio
 execute "vnoremap <buffer> m :call <SID>ProcessSelection('Moving',  function('PRE_MoveOrCopy'), function('NERDTree_MoveOrCopy', ['Moving']), function('POST_MoveOrCopy'), 0, ".g:nerdtree_vis_confirm_move.")<CR>"
 execute "vnoremap <buffer> c :call <SID>ProcessSelection('Copying', function('PRE_MoveOrCopy'), function('NERDTree_MoveOrCopy', ['Copying']), function('POST_MoveOrCopy'), 0, ".g:nerdtree_vis_confirm_copy.")<CR>"
 
-execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpNextSibling .
-\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpNextSibling )\<CR>mmgv'm"
-execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpPrevSibling .
-\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpPrevSibling )\<CR>mmgv'm"
-execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpFirstChild .
-\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpFirstChild )\<CR>mmgv'm"
-execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpLastChild .
-\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpLastChild )\<CR>mmgv'm"
-execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpParent .
-\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpParent)\<CR>mmgv'm"
-execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpRoot .
-\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpRoot)\<CR>mmgv'm"
+" --------------------------------------------------------------------------------
+" Jump Support
+function s:NERDTree_VisRemap(key)
+    return "vnoremap <buffer><silent>".eval(a:key)." <esc>:call g:NERDTreeKeyMap.Invoke(".a:key.")<CR>mmgv'm"
+endfunction
 
+execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpNextSibling" )
+execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpPrevSibling" )
+execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpFirstChild" )
+execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpLastChild" )
+execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpParent" )
+execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpRoot" )
+
+" --------------------------------------------------------------------------------
 if exists("g:nerdtree_visual_selection")
     finish
 endif
@@ -86,11 +87,6 @@ function! s:ProcessSelection(action, setup, callback, cleanup, closeWhenDone, co
         return
     endif
 
-    if empty(g:NERDTreeFileNode.GetSelected())
-        call nerdtree#echo("Could not parse selection.")
-        return
-    endif
-
     if type(a:setup) == v:t_func
         if !a:setup()
             return
@@ -102,6 +98,10 @@ function! s:ProcessSelection(action, setup, callback, cleanup, closeWhenDone, co
     while curLine <= a:lastline
         call cursor(curLine, 1)
         let node = g:NERDTreeFileNode.GetSelected()
+        if empty(node)
+            let curLine += 1
+            continue
+        endif
         call nerdtree#echo(a:action . " " . node.path.str() . " (" . (curLine - a:firstline + 1) . " of " . (a:lastline - a:firstline + 1) . ")...")
         if a:confirmEachNode && l:response < 3
             let l:response = confirm("Are you sure? ", "&Yes\n&No\n&All\n&Cancel")

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -13,8 +13,10 @@ execute "vnoremap <buffer> c :call <SID>ProcessSelection('Copying', function('PR
 
 " --------------------------------------------------------------------------------
 " Jump Support
+let g:nerdtree_vis_jumpmark = "n"
+
 function s:NERDTree_VisRemap(key)
-    return "vnoremap <buffer><silent>".eval(a:key)." <esc>:call g:NERDTreeKeyMap.Invoke(".a:key.")<CR>mmgv'm"
+  return "vnoremap <buffer><silent>" .eval(a:key) ." <esc>:call g:NERDTreeKeyMap.Invoke(" .a:key .")<CR>m" .g:nerdtree_vis_jumpmark ."gv'" .g:nerdtree_vis_jumpmark
 endfunction
 
 execute s:NERDTree_VisRemap( "g:NERDTreeMapJumpNextSibling" )

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -11,6 +11,19 @@ execute "vnoremap <buffer> d :call <SID>ProcessSelection('Deleting', '', functio
 execute "vnoremap <buffer> m :call <SID>ProcessSelection('Moving',  function('PRE_MoveOrCopy'), function('NERDTree_MoveOrCopy', ['Moving']), function('POST_MoveOrCopy'), 0, ".g:nerdtree_vis_confirm_move.")<CR>"
 execute "vnoremap <buffer> c :call <SID>ProcessSelection('Copying', function('PRE_MoveOrCopy'), function('NERDTree_MoveOrCopy', ['Copying']), function('POST_MoveOrCopy'), 0, ".g:nerdtree_vis_confirm_copy.")<CR>"
 
+execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpNextSibling .
+\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpNextSibling )\<CR>mmgv'm"
+execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpPrevSibling .
+\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpPrevSibling )\<CR>mmgv'm"
+execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpFirstChild .
+\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpFirstChild )\<CR>mmgv'm"
+execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpLastChild .
+\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpLastChild )\<CR>mmgv'm"
+execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpParent .
+\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpParent)\<CR>mmgv'm"
+execute "vnoremap <buffer> <silent>" . g:NERDTreeMapJumpRoot .
+\" <esc>:call g:NERDTreeKeyMap.Invoke( g:NERDTreeMapJumpRoot)\<CR>mmgv'm"
+
 if exists("g:nerdtree_visual_selection")
     finish
 endif
@@ -70,6 +83,11 @@ endfunction
 function! s:ProcessSelection(action, setup, callback, cleanup, closeWhenDone, confirmEachNode) range
     if b:NERDTree.isWinTree()
         call nerdtree#echo("Command is unavailable. Open NERDTree with :NERDTree, :NERDTreeToggle, or :NERDTreeFocus instead.")
+        return
+    endif
+
+    if empty(g:NERDTreeFileNode.GetSelected())
+        call nerdtree#echo("Could not parse selection.")
         return
     endif
 


### PR DESCRIPTION
the jump-mark way of getting back the selection after jumping may not be the the cleanest but it works for me,
and the error that the guard fixed was probably known but unreferenced, you could reproduce it by entering a visual selection mode, including a "non valid node" line (like the `" Press ? key for help` or `.. (up a dir)` ) in your selection and trying to perform an action (like `m`, `o`, `c`, etc...)