### PR TITLE
Avoid E122 warning

### DIFF
--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -15,7 +15,7 @@ execute "vnoremap <buffer> c :call <SID>ProcessSelection('Copying', function('PR
 " Jump Support
 let g:nerdtree_vis_jumpmark = "n"
 
-function s:NERDTree_VisRemap(key)
+function! s:NERDTree_VisRemap(key)
   return "vnoremap <buffer><silent>" .eval(a:key) ." <esc>:call g:NERDTreeKeyMap.Invoke(" .a:key .")<CR>m" .g:nerdtree_vis_jumpmark ."gv'" .g:nerdtree_vis_jumpmark
 endfunction
 


### PR DESCRIPTION
Hi @PhilRunninger, thank you for creating the awesome plugin.
<img width="1072" alt="image" src="https://github.com/PhilRunninger/nerdtree-visual-selection/assets/41264693/9b48f0da-9395-4368-a08d-b0dfdb2cce0e">
I have occurred the `E122` error by open vim in WindowTree. Even through the plugin is not working well in WindowTree, but the crash should be avoided. The fix is very small and I believe no extra affects