### PR TITLE
Added add to arglist and set arglist

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ By default, all operations ask to be confirmed with a `Yes/No/All/Cancel` prompt
 * `g:nerdtree_vis_confirm_delete`
 * `g:nerdtree_vis_confirm_copy`
 * `g:nerdtree_vis_confirm_move`
+* `g:nerdtree_vis_confirm_append_arglist`
+* `g:nerdtree_vis_confirm_set_arglist`
 
 A [mark](http://vimdoc.sourceforge.net/htmldoc/motion.html#mark-motions) is used to make your NERDTree's `Jump` mappings work while keeping your selection. By default the mark is on the `n` key, if you already use this key for a mark inside NERDTree you can change it via `g:nerdtree_vis_jumpmark`
 
@@ -39,6 +41,8 @@ NERDTreeMapOpenInTab    | <kbd>t</kbd>  | Open selected files in tabs.
 *n/a*                   | <kbd>d</kbd> | Delete selected files from disk. If open in Vim, they remain open.
 *n/a*                   | <kbd>m</kbd>  | Move the selected files to another directory. If open in Vim, the buffer still points to its old location.
 *n/a*                   | <kbd>c</kbd>  | Copy selected files to another directory.
+*n/a*                   | <kbd>a</kbd>  | Append selected files to the arglist. If a directory is selected, it is ignored. Only files will be added.
+*n/a*                   | <kbd>A</kbd>  | Set the arglist to only selected file. This overwrites the previeous arglist. If a directory is selected, it is ignored. Only files will be added.
 NERDTreeMapJumpRoot        | <kbd>P</kbd>    | Jump to the tree root.
 NERDTreeMapJumpParent      | <kbd>p</kbd>    | Jump to the parent node of the cursor node.
 NERDTreeMapJumpFirstChild  | <kbd>K</kbd>    | Jump to the first child of the cursor node's parent.

--- a/ftplugin/nerdtree.vim
+++ b/ftplugin/nerdtree.vim
@@ -2,6 +2,8 @@ let g:nerdtree_vis_confirm_open = get(g:, 'nerdtree_vis_confirm_open', 1)
 let g:nerdtree_vis_confirm_delete = get(g:, 'nerdtree_vis_confirm_delete', 1)
 let g:nerdtree_vis_confirm_move = get(g:, 'nerdtree_vis_confirm_move', 1)
 let g:nerdtree_vis_confirm_copy = get(g:, 'nerdtree_vis_confirm_copy', 1)
+let g:nerdtree_vis_confirm_append_arglist = get(g:, 'nerdtree_vis_confirm_append_arglist', 1)
+let g:nerdtree_vis_confirm_set_arglist = get(g:, 'nerdtree_vis_confirm_set_arglist', 1)
 
 execute "vnoremap <buffer> " . g:NERDTreeMapActivateNode . " :call <SID>ProcessSelection('Opening', '', function('NERDTree_Open', ['p']), '', 1, ".g:nerdtree_vis_confirm_open.")<CR>"
 execute "vnoremap <buffer> " . g:NERDTreeMapOpenSplit .    " :call <SID>ProcessSelection('Opening', '', function('NERDTree_Open', ['h']), '', 1, ".g:nerdtree_vis_confirm_open.")<CR>"
@@ -10,6 +12,8 @@ execute "vnoremap <buffer> " . g:NERDTreeMapOpenInTab .    " :call <SID>ProcessS
 execute "vnoremap <buffer> d :call <SID>ProcessSelection('Deleting', '', function('NERDTree_Delete'), '', 0, ".g:nerdtree_vis_confirm_delete.")<CR>"
 execute "vnoremap <buffer> m :call <SID>ProcessSelection('Moving',  function('PRE_MoveOrCopy'), function('NERDTree_MoveOrCopy', ['Moving']), function('POST_MoveOrCopy'), 0, ".g:nerdtree_vis_confirm_move.")<CR>"
 execute "vnoremap <buffer> c :call <SID>ProcessSelection('Copying', function('PRE_MoveOrCopy'), function('NERDTree_MoveOrCopy', ['Copying']), function('POST_MoveOrCopy'), 0, ".g:nerdtree_vis_confirm_copy.")<CR>"
+execute "vnoremap <buffer> a :call <SID>ProcessSelection('Appending to arglist', '', function('NERDTree_AppendToArglist'), '', 0, ".g:nerdtree_vis_confirm_append_arglist.")<CR>"
+execute "vnoremap <buffer> A :call <SID>ProcessSelection('Setting arglist', function('NERDTree_DeleteArglist'), function('NERDTree_AppendToArglist'), '', 0, ".g:nerdtree_vis_confirm_set_arglist.")<CR>"
 
 " --------------------------------------------------------------------------------
 " Jump Support
@@ -79,6 +83,26 @@ endfunction
 
 function! POST_MoveOrCopy()
     unlet! s:destination
+endfunction
+
+" --------------------------------------------------------------------------------
+" Append to Arglist
+function! NERDTree_DeleteArglist()
+    execute "argdelete *"
+    return 1
+endfunction
+
+function! NERDTree_AppendToArglist(node)
+    let l:file = a:node.path.str()
+    if filereadable(l:file)
+        execute "argadd " . l:file
+        return 1
+    else
+        call nerdtree#echo("File not found: Make sure the file exists and is readable.")
+        return 0
+    endif
+
+    return 0
 endfunction
 
 " --------------------------------------------------------------------------------


### PR DESCRIPTION
* Added the ability to add a visual selection of nodes to the arglist

When using visual selection pressing 'a' will append the current selection to the arglist. Pressing 'A' will overwrite it by emptying the list before appending the selected nodes.
This function only adds readable files and ignores directories and non-existant or otherwise undreadable files.

The user will experience:
1. Confirm whether to add node to arglist.

* Update the README file with the new features